### PR TITLE
remove nonce, gasPrice, gasFee, maxFeePerGass

### DIFF
--- a/Example/CarteraExample/ViewController.swift
+++ b/Example/CarteraExample/ViewController.swift
@@ -231,10 +231,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
                                                   gasPrice: nil,
                                                   gasLimit: nil,
                                                   chainId: self.chainId)
-            let ethereumRequest = EthereumTransactionRequest(transaction: transaction,
-                                                             gasPrice: BigUInt(10000000),
-                                                             gas: BigUInt(10000000),
-                                                             nonce: nil)
+            let ethereumRequest = EthereumTransactionRequest(transaction: transaction)
             let request = WalletTransactionRequest(walletRequest: walletRequest, ethereum: ethereumRequest)
             self.provider.send(request: request, connected: { info in
                 print("connected: \(info?.address ?? "")")

--- a/Sources/Cartera/WalletProvider/Providers/WalletConnectV1Provider.swift
+++ b/Sources/Cartera/WalletProvider/Providers/WalletConnectV1Provider.swift
@@ -256,32 +256,26 @@ final class WalletConnectV1Provider: NSObject, WalletOperationProviderProtocol {
 
     private func translate(ethereumTransactionRequest: EthereumTransactionRequest) -> Client.Transaction? {
         let transaction = ethereumTransactionRequest.transaction
-        let gasPrice = ethereumTransactionRequest.gasPrice
-        let gas = ethereumTransactionRequest.gas
         
         if let from = transaction.from {
-            let maxPriorityFeePerGas = BigUInt(1500000000)
-            var maxFeePerGas: BigUInt?
-            if let gasPrice = gasPrice {
-                maxFeePerGas = (maxPriorityFeePerGas + gasPrice) * 11 / 10
-            }
 
             let dataText = transaction.data?.web3.hexString
-            let gasText = gas?.web3.hexString
-            let gasPriceText = gasPrice?.web3.hexString
             let valueText = transaction.value?.web3.hexString
-            let nonce: String? = nil // nonce?.web3.hexString, let it be automatic
-            let maxPriorityFeePerGasText = maxPriorityFeePerGas.web3.hexString
-            let maxFeePerGasText = maxFeePerGas?.web3.hexString
 
-            Console.shared.log("Transaction: Gas \(gas?.description ?? "")")
-            Console.shared.log("Transaction: GasPrice \(gasPrice?.description ?? "")")
             Console.shared.log("Transaction: Value \(transaction.value?.description ?? "")")
-            Console.shared.log("Transaction: Nonce \(nonce ?? "")")
-            Console.shared.log("Transaction: maxPriorityFeePerGasText \(maxPriorityFeePerGas.description)")
-            Console.shared.log("Transaction: maxFeePerGasText \(maxFeePerGas?.description ?? "")")
 
-            return Client.Transaction(from: from.asString(), to: transaction.to.asString(), data: dataText ?? "0x", gas: gasText, gasPrice: gasPriceText, value: valueText, nonce: nonce, type: nil, accessList: nil, chainId: nil, maxPriorityFeePerGas: maxPriorityFeePerGasText, maxFeePerGas: maxFeePerGasText)
+            return Client.Transaction(from: from.asString(), 
+                                      to: transaction.to.asString(),
+                                      data: dataText ?? "0x",
+                                      gas: nil,
+                                      gasPrice: nil,
+                                      value: valueText, 
+                                      nonce: nil,
+                                      type: nil,
+                                      accessList: nil,
+                                      chainId: nil,
+                                      maxPriorityFeePerGas: nil,
+                                      maxFeePerGas: nil)
         } else {
             return nil
         }

--- a/Sources/Cartera/WalletProvider/Providers/WalletConnectV2Provider.swift
+++ b/Sources/Cartera/WalletProvider/Providers/WalletConnectV2Provider.swift
@@ -530,52 +530,21 @@ extension WalletInfo {
 }
 
 struct Transaction: Codable {
-    let from, to, data, gas: String
-    let gasPrice, value, nonce: String
-    let maxPriorityFeePerGas, maxFeePerGas: String
+    let from, to, data: String
     
     init?(ethereumTransactionRequest: EthereumTransactionRequest) {
         let transaction = ethereumTransactionRequest.transaction
-        let gasPrice = ethereumTransactionRequest.gasPrice
-        let gas = ethereumTransactionRequest.gas
-        let nonce = ethereumTransactionRequest.nonce
         
         if let from = transaction.from {
             let maxPriorityFeePerGas: BigUInt?
             let maxFeePerGas: BigUInt?
-            
-            if let maxPriorityFeePerGasValue = ethereumTransactionRequest.maxPriorityFeePerGas,
-               let maxFeePerGasValue = ethereumTransactionRequest.maxFeePerGas {
-                maxPriorityFeePerGas = BigUInt(maxPriorityFeePerGasValue)
-                maxFeePerGas = BigUInt(maxFeePerGasValue)
-            } else {
-                if let gasPrice = gasPrice {
-                    maxPriorityFeePerGas = BigUInt(1500000000)
-                    maxFeePerGas = (maxPriorityFeePerGas! + gasPrice) * 11 / 10
-                } else {
-                    maxPriorityFeePerGas = nil
-                    maxFeePerGas = nil
-                }
-            }
 
             let dataText = transaction.data?.web3.hexString
-            let gasText = gas?.web3.hexString
-            let gasPriceText = gasPrice?.web3.hexString
             let valueText = transaction.value?.web3.hexString
-            let nonce: String? = nonce?.web3.hexString
-            let maxPriorityFeePerGasText = maxPriorityFeePerGas?.web3.hexString
-            let maxFeePerGasText = maxFeePerGas?.web3.hexString
 
             self.from = from.asString()
             self.to = transaction.to.asString()
             self.data =  dataText ?? "0x"
-            self.gas = gasText ?? "0x"
-            self.gasPrice = gasPriceText ?? "0x"
-            self.value = valueText ?? "0x"
-            self.nonce = nonce  ?? "0x"
-            self.maxPriorityFeePerGas = maxPriorityFeePerGasText ?? "0x"
-            self.maxFeePerGas = maxFeePerGasText ?? "0x"
-            
         } else {
             return nil
         }

--- a/Sources/Cartera/WalletProvider/Providers/WalletSegueProvider.swift
+++ b/Sources/Cartera/WalletProvider/Providers/WalletSegueProvider.swift
@@ -243,34 +243,26 @@ private extension Action {
 
             let chainId = transactionRequest.walletRequest.chainId
             let transaction = ethereum.transaction
-            let gasPrice =  ethereum.gasPrice
-            let gas = ethereum.gas
 
             let dataText = transaction.data?.web3.hexString ?? "0x"
-            let gasText = String(bigUInt: gas)
-            let gasPriceText = String(bigUInt: gasPrice)
             let valueText = String(bigUInt: transaction.value) ?? "0"
-            let nonce: Int? = nil
             let chainIdText: String
             if let chainId = chainId {
                 chainIdText = "\(chainId)"
             } else {
                 chainIdText = "1"
             }
-            
-            let maxFeePerGas = String(bigUInt: ethereum.maxFeePerGas)
-            let maxPriorityFeePerGas = String(bigUInt: ethereum.maxPriorityFeePerGas)
 
             self.init(jsonRpc: .eth_sendTransaction(
                 fromAddress: from.asString().uppercased(),
                 toAddress: ethereum.transaction.to.asString(),
                 weiValue: valueText,
                 data: dataText,
-                nonce: nonce,
-                gasPriceInWei: gasPriceText,
-                maxFeePerGas: maxFeePerGas,
-                maxPriorityFeePerGas: maxPriorityFeePerGas,
-                gasLimit: gasText,
+                nonce: nil,
+                gasPriceInWei: nil,
+                maxFeePerGas: nil,
+                maxPriorityFeePerGas: nil,
+                gasLimit: nil,
                 chainId: chainIdText)
             )
         } else {

--- a/Sources/Cartera/WalletProvider/UserConsent/SimpleWalletUserConsent.swift
+++ b/Sources/Cartera/WalletProvider/UserConsent/SimpleWalletUserConsent.swift
@@ -13,14 +13,6 @@ final public class SimpleWalletUserConsent: WalletUserConsentProtocol {
     public init() {}
 
     public func showTransactionConsent(request: WalletTransactionRequest, completion: WalletUserConsentCompletion?) {
-        let gasString: String
-        if let gas = request.ethereum?.gas, let gasPrice = request.ethereum?.gasPrice {
-            let gasCost = gas.multiplied(by: gasPrice)
-            let gasDouble = (Double(String(gasCost)) ?? 0.0) / 1_000_000_000
-            gasString = "\(gasDouble) Gwei"
-        } else {
-            gasString = ""
-        }
         let valueString: String
         if let value = request.ethereum?.transaction.value {
             let valueDouble = (Double(String(value)) ?? 0.0) / 1_000_000_000 / 1_000_000_000
@@ -28,7 +20,7 @@ final public class SimpleWalletUserConsent: WalletUserConsentProtocol {
         } else {
             valueString = ""
         }
-        let alert = UIAlertController(title: "Approve this transaction?", message: "Esimated gas: \(gasString).  Transaction value: \(valueString)", preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: "Approve this transaction?", message: "Transaction value: \(valueString)", preferredStyle: .actionSheet)
 
         alert.addAction(UIAlertAction(title: "Approve", style: .default, handler: { _ in
             completion?(.consented)

--- a/Sources/Cartera/WalletProvider/WalletProviderProtocols.swift
+++ b/Sources/Cartera/WalletProvider/WalletProviderProtocols.swift
@@ -35,24 +35,10 @@ public struct WalletTransactionRequest {
 
 public struct EthereumTransactionRequest {
     public let transaction: EthereumTransaction
-    public let gasPrice: BigUInt?
-    public let gas: BigUInt?
-    public let nonce: Int?
-    public let maxPriorityFeePerGas: BigUInt?
-    public let maxFeePerGas: BigUInt?
     
-    public init(transaction: EthereumTransaction,
-                gasPrice: BigUInt?,
-                gas: BigUInt?,
-                nonce: Int?,
-                maxPriorityFeePerGas: BigUInt? = nil,
-                maxFeePerGas: BigUInt? = nil) {
+    
+    public init(transaction: EthereumTransaction) {
         self.transaction = transaction
-        self.gasPrice = gasPrice
-        self.gas = gas
-        self.nonce = nonce
-        self.maxPriorityFeePerGas = maxPriorityFeePerGas
-        self.maxFeePerGas = maxFeePerGas
     }
 }
 


### PR DESCRIPTION
these values should all be decided by the wallet, have tested deposits with metamask newly work after removing these parameters. No longer seeing `cannot mix gasPrice and maxFeePerGas` error

- `nonce` should be removed since pending transactions in wallet maybe not be reflected by the dApp's generated nonce
- no need for `gasPrice` to be set since EIP 1559 see [metamask docs](https://metamask.io/1559/#:~:text=If%20the%20dapps%20haven't,potentially%20overpay%20for%20their%20transaction.)
> If the dapps haven't switched over to the new EIP-1559 fields, MetaMask will detect this and use gasPrice as maxFeePerGas. This means the user will potentially overpay for their transaction. As of December 2021, EIP-1559 is used by about 50% penetration.
- no need for `maxFeePerGas` since wallet decides and get user's explicit confirmation anyways in wallet UI