### PR TITLE
Fix Phantom Wallet sendTransaction

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Cartera.podspec
+++ b/Cartera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Cartera'
-  s.version          = '0.1.11'
+  s.version          = '0.1.12'
   s.summary          = 'Web3 mobile wallet connection library for iOS'
   s.homepage         = 'https://github.com/dydxprotocol/cartera-ios'
   s.license          = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/Example/CarteraExample.xcodeproj/project.pbxproj
+++ b/Example/CarteraExample.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		027A7C5729A6C93B009116E4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 027A7C5529A6C93B009116E4 /* LaunchScreen.storyboard */; };
 		027A7ED829A8679B009116E4 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = 027A7ED729A8679B009116E4 /* SDWebImage */; };
 		027CAEFE2A5769440072956B /* QrCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027CAEFD2A5769440072956B /* QrCodeViewController.swift */; };
-		02886BCB2D84AECF005EF461 /* SolanaInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02886BCA2D84AECF005EF461 /* SolanaInteractor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,7 +54,6 @@
 		027A7C5629A6C93B009116E4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		027A7C5829A6C93B009116E4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		027CAEFD2A5769440072956B /* QrCodeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QrCodeViewController.swift; sourceTree = "<group>"; };
-		02886BCA2D84AECF005EF461 /* SolanaInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolanaInteractor.swift; sourceTree = "<group>"; };
 		02CAD9E429C2401800D6076C /* CarteraExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CarteraExample.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -123,7 +121,6 @@
 				027A7C4C29A6C93A009116E4 /* SceneDelegate.swift */,
 				027A7C4E29A6C93A009116E4 /* ViewController.swift */,
 				027CAEFD2A5769440072956B /* QrCodeViewController.swift */,
-				02886BCA2D84AECF005EF461 /* SolanaInteractor.swift */,
 				027A7C5029A6C93A009116E4 /* Main.storyboard */,
 				027A7C5329A6C93B009116E4 /* Assets.xcassets */,
 				027A7C5529A6C93B009116E4 /* LaunchScreen.storyboard */,
@@ -259,7 +256,6 @@
 			files = (
 				027A7C4F29A6C93A009116E4 /* ViewController.swift in Sources */,
 				027A7C4B29A6C93A009116E4 /* AppDelegate.swift in Sources */,
-				02886BCB2D84AECF005EF461 /* SolanaInteractor.swift in Sources */,
 				027CAEFE2A5769440072956B /* QrCodeViewController.swift in Sources */,
 				027A7C4D29A6C93A009116E4 /* SceneDelegate.swift in Sources */,
 			);

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "base58swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/heckj/Base58Swift.git",
+      "state" : {
+        "revision" : "3ba16c02089401c817b631ffc33ca8f022a41538",
+        "version" : "2.1.15"
+      }
+    },
+    {
       "identity" : "bigint",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt",
       "state" : {
-        "revision" : "19f5e8a48be155e34abb98a2bcf4a343316f0343",
-        "version" : "5.0.0"
+        "revision" : "793a7fac0bfc318e85994bf6900652e827aef33e",
+        "version" : "5.4.1"
       }
     },
     {
@@ -19,12 +28,21 @@
       }
     },
     {
-      "identity" : "generic-json-swift",
+      "identity" : "hdwallet",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/iwill/generic-json-swift",
+      "location" : "https://github.com/WalletConnect/HDWallet",
       "state" : {
-        "revision" : "0a06575f4038b504e78ac330913d920f1630f510",
-        "version" : "2.0.2"
+        "branch" : "develop",
+        "revision" : "748a85b1dfe9a2fa592bd9266c5a926e4e1d3f44"
+      }
+    },
+    {
+      "identity" : "promisekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/PromiseKit.git",
+      "state" : {
+        "revision" : "8a98e31a47854d3180882c8068cc4d9381bf382d",
+        "version" : "6.22.1"
       }
     },
     {
@@ -39,10 +57,19 @@
     {
       "identity" : "secp256k1.swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/GigaBitcoin/secp256k1.swift.git",
+      "location" : "https://github.com/Boilertalk/secp256k1.swift.git",
       "state" : {
-        "revision" : "48fb20fce4ca3aad89180448a127d5bc16f0e44c",
-        "version" : "0.10.0"
+        "revision" : "cd187c632fb812fd93711a9f7e644adb7e5f97f0",
+        "version" : "0.1.7"
+      }
+    },
+    {
+      "identity" : "solana-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dydxprotocol/solana-swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "3212af8f57321f81ae7035c27388c2a9cde11ab0"
       }
     },
     {
@@ -52,60 +79,6 @@
       "state" : {
         "branch" : "3.1.2",
         "revision" : "a063fda2b8145a231953c20e7a646be254365396"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-        "version" : "1.0.3"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "45167b8006448c79dda4b7bd604e07a034c15c49",
-        "version" : "2.48.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "4fb7ead803e38949eb1d6fabb849206a72c580f3",
-        "version" : "2.23.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "c0d9a144cfaec8d3d596aadde3039286a266c15c",
-        "version" : "1.15.0"
       }
     },
     {
@@ -127,9 +100,27 @@
       }
     },
     {
+      "identity" : "task-retrying-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/bigearsenal/task-retrying-swift.git",
+      "state" : {
+        "revision" : "208f1e8dfa93022a7d39ab5b334d5f43a934d4b1",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "tweetnacl-swiftwrap",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git",
+      "state" : {
+        "revision" : "f8fd111642bf2336b11ef9ea828510693106e954",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "wallet-mobile-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/coinbase/wallet-mobile-sdk",
+      "location" : "https://github.com/MobileWalletProtocol/wallet-mobile-sdk",
       "state" : {
         "branch" : "1.0.5",
         "revision" : "4aa89e682f8d7ab1515d85d0797f0d25306bb56a"
@@ -147,19 +138,19 @@
     {
       "identity" : "walletconnectswiftv2",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/WalletConnect/WalletConnectSwiftV2.git",
+      "location" : "https://github.com/dydxprotocol/WalletConnectSwiftV2.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "58d2b49eeac5cf94432e2647b9107577c156a25c"
+        "branch" : "develop",
+        "revision" : "0d9a566b375a29fcc36e3ce66824c49925fa72aa"
       }
     },
     {
-      "identity" : "websocket-kit",
+      "identity" : "web3.swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/websocket-kit.git",
+      "location" : "https://github.com/WalletConnect/Web3.swift",
       "state" : {
-        "revision" : "2d9d2188a08eef4a869d368daab21b3c08510991",
-        "version" : "2.6.1"
+        "revision" : "569255adcfff0b37e4cb8004aea29d0e2d6266df",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/Sources/Cartera/WalletProvider/Providers/SolanaInteractor.swift
+++ b/Sources/Cartera/WalletProvider/Providers/SolanaInteractor.swift
@@ -48,4 +48,13 @@ public final class SolanaInteractor {
         }
         return balance
     }
+    
+    public func sendTransaction(transaction: String) async throws -> String {
+        guard let configs = RequestConfiguration(encoding: "base58") else {
+            throw NSError(domain: "SolanaInteractor", code: 0, userInfo: nil)
+        }
+        let result = try await apiClient.sendTransaction(transaction: transaction,
+                                                         configs: configs)
+        return result
+    }
 }


### PR DESCRIPTION
Phantom Wallet SDK deprecated [SignAndSendTransaction](https://docs.phantom.com/phantom-deeplinks/provider-methods/signandsendtransaction), and now we have to do the submission ourselves.